### PR TITLE
[Fix] 42로그인 뷰 리턴값에 유저닉네임 추가

### DIFF
--- a/transcendence-api/users/views.py
+++ b/transcendence-api/users/views.py
@@ -83,10 +83,12 @@ def get_token(request):
         token = TokenObtainPairSerializer.get_token(user)  # refresh token 생성
         refresh_token = str(token)
         access_token = str(token.access_token)  # access token 생성
+        nickname = user.nickname
         response_data = {
             "message": message,
             "access_token": access_token,
-            "refresh_token": refresh_token
+            "refresh_token": refresh_token,
+            "nickname": nickname,
         }
     else:
         # 새로운 유저 생성


### PR DESCRIPTION
42로그인 시 닉네임 설정 페이지로 이동하는 오류 해결하기 위해, 로그인뷰 리턴값에 유저닉네임 추가했습니다.